### PR TITLE
[# 148392097] Add Facts#peek to Factree

### DIFF
--- a/lib/factree/facts.rb
+++ b/lib/factree/facts.rb
@@ -38,7 +38,12 @@ class Factree::Facts
   # @param [Symbol] fact_name
   # @return [Object]
   def [](fact_name)
-    self.require(fact_name)
+    self.require fact_name
+    peek fact_name
+  end
+
+  # Gets the value of a fact, if present, without {#require}ing the fact.
+  def peek(fact_name)
     @hash[fact_name]
   end
 

--- a/test/factree/facts_test.rb
+++ b/test/factree/facts_test.rb
@@ -23,6 +23,12 @@ describe Factree::Facts do
     end
   end
 
+  describe '#peek' do
+    it "looks in the hash" do
+      assert_equal :in_a_box, subject[:location]
+    end
+  end
+
   describe "#require" do
     it "throws when missing facts" do
       assert_nil(Factree::Facts.catch_missing_facts {


### PR DESCRIPTION
Add `Facts#peek` to allow access to facts without requiring them. Note that
```ruby
facts[:foo] if facts.known?(:foo)
```
will cause `:foo` to show up in a Path's [required facts](http://www.rubydoc.info/github/consultingmd/factree/master/Factree/Path#required_facts-instance_method), while
```ruby
facts.peek(:foo)
```
will not.

[Tracker #148392097](https://www.pivotaltracker.com/story/show/148392097)